### PR TITLE
fix: Sửa logic deadline pause cho complete/cancel/pending_completion

### DIFF
--- a/src/pages/ServiceBoosting.vue
+++ b/src/pages/ServiceBoosting.vue
@@ -1710,8 +1710,11 @@ function formatDeadline(
   if (!endTs) return { text: '—', color: 'default' as const }
 
   const isSelfplay = serviceType === 'Selfplay'
-  if (isSelfplay && (status === 'new' || status === 'paused_selfplay')) {
-    const referenceTs = status === 'paused_selfplay' && pausedAt ? toTs(pausedAt) : startTs
+  if (isSelfplay && (status === 'new' || status === 'paused_selfplay' || status === 'pending_completion')) {
+    const referenceTs =
+      status === 'paused_selfplay' && pausedAt ? toTs(pausedAt) :
+      status === 'pending_completion' && pausedAt ? toTs(pausedAt) :
+      startTs
 
     if (referenceTs) {
       const remainingMs = endTs - referenceTs
@@ -1729,13 +1732,17 @@ function formatDeadline(
       if (status === 'paused_selfplay') {
         return { text: `Tạm dừng (còn ${timeString})`, color: 'info' as const }
       }
+      if (status === 'pending_completion') {
+        return { text: `Chờ duyệt (còn ${timeString})`, color: 'warning' as const }
+      }
       return { text: `Chờ (còn ${timeString})`, color: 'default' as const }
     }
   }
 
   // Logic cho các trạng thái còn lại giữ nguyên
   if (status === 'completed') {
-    const completionTs = toTs(updatedAt) ?? nowMs
+    // Ưu tiên paused_at (thời điểm dừng deadline), fallback về updatedAt
+    const completionTs = toTs(pausedAt) ?? toTs(updatedAt) ?? nowMs
     const diffMs = endTs - completionTs
     const absDiffMs = Math.abs(diffMs)
 

--- a/supabase/migrations/20251003170000_fix_deadline_pause_logic.sql
+++ b/supabase/migrations/20251003170000_fix_deadline_pause_logic.sql
@@ -1,0 +1,155 @@
+-- Fix deadline pause logic cho complete, cancel order và pending_completion
+-- 1. Complete order: set paused_at khi in_progress
+-- 2. Cancel order: set paused_at khi in_progress
+-- 3. Trigger pending_completion: chỉ set paused_at cho Selfplay
+
+-- ============================================
+-- 1. Fix complete_order_line_v1
+-- ============================================
+CREATE OR REPLACE FUNCTION public.complete_order_line_v1(p_line_id uuid, p_completion_proof_urls text[], p_reason text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  target_order_id uuid;
+  v_context jsonb;
+  v_current_status text;
+BEGIN
+  -- Bước 1: Lấy order_id, status và ngữ cảnh từ p_line_id
+  SELECT
+    ol.order_id,
+    o.status,
+    jsonb_build_object('game_code', o.game_code, 'business_area_code', 'SERVICE')
+  INTO
+    target_order_id,
+    v_current_status,
+    v_context
+  FROM public.order_lines ol
+  JOIN public.orders o ON ol.order_id = o.id
+  WHERE ol.id = p_line_id;
+
+  IF target_order_id IS NULL THEN
+    RAISE EXCEPTION 'Order line not found';
+  END IF;
+
+  -- Bước 2: Kiểm tra quyền hạn VỚI NGỮ CẢNH ĐẦY ĐỦ
+  IF NOT has_permission('orders:complete', v_context) THEN
+    RAISE EXCEPTION 'User does not have permission to complete orders';
+  END IF;
+
+  -- Bước 3: Dừng deadline nếu đang in_progress
+  IF v_current_status = 'in_progress' THEN
+    UPDATE public.order_lines
+    SET paused_at = NOW()
+    WHERE id = p_line_id;
+  END IF;
+
+  -- Bước 4: Cập nhật trạng thái và lưu bằng chứng
+  UPDATE public.orders
+  SET
+    status = 'completed',
+    notes = p_reason
+  WHERE id = target_order_id;
+
+  UPDATE public.order_lines
+  SET
+    action_proof_urls = p_completion_proof_urls
+  WHERE id = p_line_id;
+
+END;
+$function$;
+
+-- ============================================
+-- 2. Fix cancel_order_line_v1
+-- ============================================
+CREATE OR REPLACE FUNCTION public.cancel_order_line_v1(p_line_id uuid, p_cancellation_proof_urls text[], p_reason text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  target_order_id uuid;
+  v_context jsonb;
+  v_current_status text;
+BEGIN
+  -- Bước 1: Lấy order_id, status và ngữ cảnh từ order_line_id
+  SELECT
+    ol.order_id,
+    o.status,
+    jsonb_build_object('game_code', o.game_code, 'business_area_code', 'SERVICE')
+  INTO
+    target_order_id,
+    v_current_status,
+    v_context
+  FROM public.order_lines ol
+  JOIN public.orders o ON ol.order_id = o.id
+  WHERE ol.id = p_line_id;
+
+  IF target_order_id IS NULL THEN
+    RAISE EXCEPTION 'Order line not found';
+  END IF;
+
+  -- Bước 2: Kiểm tra quyền hạn VỚI NGỮ CẢNH ĐẦY ĐỦ
+  IF NOT has_permission('orders:cancel', v_context) THEN
+    RAISE EXCEPTION 'User does not have permission to cancel orders';
+  END IF;
+
+  -- Bước 3: Dừng deadline nếu đang in_progress
+  IF v_current_status = 'in_progress' THEN
+    UPDATE public.order_lines
+    SET paused_at = NOW()
+    WHERE id = p_line_id;
+  END IF;
+
+  -- Bước 4: Cập nhật trạng thái và lưu bằng chứng
+  UPDATE public.orders
+  SET
+    status = 'cancelled',
+    notes = p_reason
+  WHERE id = target_order_id;
+
+  UPDATE public.order_lines
+  SET
+    action_proof_urls = p_cancellation_proof_urls
+  WHERE id = p_line_id;
+
+END;
+$function$;
+
+-- ============================================
+-- 3. Fix tr_check_all_items_completed_v1
+-- Chỉ set paused_at cho Selfplay khi pending_completion
+-- ============================================
+CREATE OR REPLACE FUNCTION public.tr_check_all_items_completed_v1()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE v_order_line_id UUID; v_order_id UUID; v_current_order_status TEXT; v_service_type TEXT; total_items INT; completed_items INT;
+BEGIN
+    IF TG_OP = 'UPDATE' AND NEW.done_qty <> OLD.done_qty THEN
+        v_order_line_id := NEW.order_line_id;
+        SELECT ol.order_id, o.status, pv.display_name
+        INTO v_order_id, v_current_order_status, v_service_type
+        FROM public.order_lines ol
+        JOIN public.orders o ON ol.order_id = o.id
+        LEFT JOIN public.product_variants pv ON ol.variant_id = pv.id
+        WHERE ol.id = v_order_line_id;
+
+        IF v_current_order_status IN ('completed', 'cancelled', 'pending_completion') THEN RETURN NEW; END IF;
+        SELECT count(*) INTO total_items FROM public.order_service_items WHERE order_line_id = v_order_line_id;
+        SELECT count(*) INTO completed_items FROM public.order_service_items WHERE order_line_id = v_order_line_id AND done_qty >= COALESCE(plan_qty, 0);
+        IF total_items > 0 AND total_items = completed_items THEN
+            -- Chỉ dừng deadline cho Selfplay khi pending_completion
+            IF v_current_order_status = 'in_progress' AND v_service_type = 'Service-Selfplay' THEN
+                UPDATE public.order_lines SET paused_at = NOW() WHERE id = v_order_line_id;
+            END IF;
+            UPDATE public.orders SET status = 'pending_completion' WHERE id = v_order_id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
Backend (RPC):
- complete_order_line_v1: Set paused_at khi complete từ in_progress
- cancel_order_line_v1: Set paused_at khi cancel từ in_progress
- tr_check_all_items_completed_v1: Chỉ set paused_at cho Selfplay khi pending_completion (Pilot vẫn đếm ngược)

Frontend (ServiceBoosting.vue):
- Sửa formatDeadline: Dùng paused_at để tính thời điểm hoàn thành cho status completed
- Selfplay pending_completion: Hiển thị "Chờ duyệt (còn X)" với paused_at
- Pilot pending_completion: Vẫn đếm ngược bình thường

🤖 Generated with [Claude Code](https://claude.com/claude-code)